### PR TITLE
Implement disableParentheses option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Apart from the phone-specific properties described below, all [Input](https://mu
 | searchNotFound     | The value is shown if `enableSearch` is `true` and the query does not match any country. Default value is `No country found`. | string                    |
 | searchPlaceholder  | The value is shown if `enableSearch` is `true`. Default value is `Search country`.                                            | string                    |
 | disableDropdown    | Disables the manual country selection through the dropdown menu.                                                              | boolean                   |
+| disableParentheses | Disables parentheses from the input masks. Default enabled.                                                                   | boolean                   |
 | onlyCountries      | Country codes to be included in the list. E.g. `onlyCountries={['us', 'ca', 'uk']}`.                                          | string[]                  |
 | excludeCountries   | Country codes to be excluded from the list of countries. E.g. `excludeCountries={['us', 'ca', 'uk']}`.                        | string[]                  |
 | preferredCountries | Country codes to be at the top of the list. E.g. `preferredCountries={['us', 'ca', 'uk']}`.                                   | string[]                  |

--- a/examples/base/package.json
+++ b/examples/base/package.json
@@ -9,7 +9,7 @@
     "@mui/material": "^5.15.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "mui-phone-input": "^0.1.0",
+    "mui-phone-input": "^0.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",

--- a/examples/core/package.json
+++ b/examples/core/package.json
@@ -8,7 +8,7 @@
     "@material-ui/core": "^4.12.4",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "mui-phone-input": "^0.1.0",
+    "mui-phone-input": "^0.1.2",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-scripts": "^5.0.1",

--- a/examples/joy/package.json
+++ b/examples/joy/package.json
@@ -8,7 +8,7 @@
     "@mui/joy": "^5.0.0-beta.15",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "mui-phone-input": "^0.1.0",
+    "mui-phone-input": "^0.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",

--- a/examples/material/package.json
+++ b/examples/material/package.json
@@ -10,7 +10,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "copy-to-clipboard": "^3.3.3",
-    "mui-phone-input": "^0.1.0",
+    "mui-phone-input": "^0.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.4",

--- a/examples/material/src/Demo.tsx
+++ b/examples/material/src/Demo.tsx
@@ -29,6 +29,7 @@ const Demo = () => {
     const [preview, setPreview] = useState<boolean>(false);
     const [dropdown, setDropdown] = useState<boolean>(true);
     const [disabled, setDisabled] = useState<boolean>(false);
+    const [parentheses, setParentheses] = useState(true);
 
     const phoneProps = register("phone", {
         validate: (value: any) => checkValidity(parsePhoneNumber(value)),
@@ -129,6 +130,16 @@ const Demo = () => {
                             style={{margin: 0}}
                             label="Dropdown"
                         />
+                        <FormControlLabel
+                            control={<Switch
+                                defaultChecked
+                                color="primary"
+                                onChange={() => setParentheses(!parentheses)}
+                            />}
+                            labelPlacement="start"
+                            style={{margin: 0}}
+                            label="Parentheses"
+                        />
                     </div>
                     <Divider textAlign="left" style={{margin: "16px 0"}}>Code</Divider>
                     <div style={{position: "relative"}}>
@@ -163,6 +174,7 @@ const Demo = () => {
                                 enableSearch={search}
                                 style={{width: "100%"}}
                                 disableDropdown={!dropdown}
+                                disableParentheses={!parentheses}
                             />
                         )}
                         {(preview && value && !error) && (

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1",
+  "version": "0.1.2",
   "name": "mui-phone-input",
   "description": "Advanced, highly customizable phone input component for Material UI.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "react-phone-hooks": "^0.1.4"
+    "react-phone-hooks": "^0.1.5"
   },
   "devDependencies": {
     "@emotion/styled": "^11.11.0",

--- a/src/base/index.tsx
+++ b/src/base/index.tsx
@@ -19,8 +19,17 @@ import {PhoneInputProps, PhoneNumber} from "./types";
 injectMergedStyles();
 
 const Input = forwardRef<HTMLInputElement, InputProps>(({slotProps, ...props}, ref) => {
-    const defaultInputProps = (slotProps?.input as any)?.className ? {} : {outline: "none", border: "none", paddingLeft: 5, width: "calc(100% - 30px)"};
-    const defaultRootProps = (slotProps?.root as any)?.className ? {} : {background: "white", color: "black", paddingLeft: 5};
+    const defaultInputProps = (slotProps?.input as any)?.className ? {} : {
+        outline: "none",
+        border: "none",
+        paddingLeft: 5,
+        width: "calc(100% - 30px)"
+    };
+    const defaultRootProps = (slotProps?.root as any)?.className ? {} : {
+        background: "white",
+        color: "black",
+        paddingLeft: 5
+    };
     return (
         <BaseInput
             ref={ref}
@@ -51,6 +60,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({slotProps, ...props}, r
 const PhoneInput = forwardRef(({
                                    value: initialValue = "",
                                    country = getDefaultISO2Code(),
+                                   disableParentheses = false,
                                    onlyCountries = [],
                                    excludeCountries = [],
                                    preferredCountries = [],
@@ -76,6 +86,7 @@ const PhoneInput = forwardRef(({
         onlyCountries,
         excludeCountries,
         preferredCountries,
+        disableParentheses,
     });
 
     const {

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -11,6 +11,8 @@ export interface PhoneInputProps extends Omit<InputProps, "onChange"> {
 
     country?: string;
 
+    disableParentheses?: boolean;
+
     onlyCountries?: string[];
 
     excludeCountries?: string[];

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -29,6 +29,7 @@ const PhoneInput = forwardRef(({
                                    disabled = false,
                                    enableSearch = false,
                                    disableDropdown = false,
+                                   disableParentheses = false,
                                    onlyCountries = [],
                                    excludeCountries = [],
                                    preferredCountries = [],
@@ -150,33 +151,36 @@ const PhoneInput = forwardRef(({
                             />
                         )}
                         <div className="mui-phone-input-search-list">
-                            {countriesList.length ? countriesList.map(([iso, name, dial, mask]) => (
-                                <MenuItem
-                                    disableRipple
-                                    key={iso + mask}
-                                    value={iso + dial}
-                                    style={{maxWidth}}
-                                    selected={selectValue === iso + dial}
-                                    onClick={() => {
-                                        const formattedNumber = getFormattedNumber(mask, mask);
-                                        const input = inputRef.current.querySelector("input");
-                                        input.value = formattedNumber;
-                                        setValue(formattedNumber);
-                                        setCountryCode(iso);
-                                        setQuery("");
-                                        const nativeInputValueSetter = (Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") as any).set;
-                                        nativeInputValueSetter.call(input, formattedNumber);
-                                        input.dispatchEvent(new Event("change", {bubbles: true}));
-                                        setTimeout(() => input.focus(), 100);
-                                    }}
-                                    children={<div className="mui-phone-input-select-item">
-                                        <div className={`flag ${iso}`}/>
-                                        <div className="label">
-                                            {name}&nbsp;{displayFormat(mask)}
-                                        </div>
-                                    </div>}
-                                />
-                            )) : <MenuItem disabled>{searchNotFound}</MenuItem>}
+                            {countriesList.length ? countriesList.map(([iso, name, dial, pattern]) => {
+                                const mask = disableParentheses ? pattern.replace(/[()]/g, "") : pattern;
+                                return (
+                                    <MenuItem
+                                        disableRipple
+                                        key={iso + mask}
+                                        value={iso + dial}
+                                        style={{maxWidth}}
+                                        selected={selectValue === iso + dial}
+                                        onClick={() => {
+                                            const formattedNumber = getFormattedNumber(mask, mask);
+                                            const input = inputRef.current.querySelector("input");
+                                            input.value = formattedNumber;
+                                            setValue(formattedNumber);
+                                            setCountryCode(iso);
+                                            setQuery("");
+                                            const nativeInputValueSetter = (Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") as any).set;
+                                            nativeInputValueSetter.call(input, formattedNumber);
+                                            input.dispatchEvent(new Event("change", {bubbles: true}));
+                                            setTimeout(() => input.focus(), 100);
+                                        }}
+                                        children={<div className="mui-phone-input-select-item">
+                                            <div className={`flag ${iso}`}/>
+                                            <div className="label">
+                                                {name}&nbsp;{displayFormat(mask)}
+                                            </div>
+                                        </div>}
+                                    />
+                                )
+                            }) : <MenuItem disabled>{searchNotFound}</MenuItem>}
                         </div>
                     </div>
                 </Select>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,6 +21,8 @@ export interface PhoneInputProps extends Omit<TextFieldProps, "onChange"> {
 
     disableDropdown?: boolean;
 
+    disableParentheses?: boolean;
+
     onlyCountries?: string[];
 
     excludeCountries?: string[];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ const PhoneInput = forwardRef(({
                                    disabled = false,
                                    enableSearch = false,
                                    disableDropdown = false,
+                                   disableParentheses = false,
                                    onlyCountries = [],
                                    excludeCountries = [],
                                    preferredCountries = [],
@@ -63,6 +64,7 @@ const PhoneInput = forwardRef(({
         onlyCountries,
         excludeCountries,
         preferredCountries,
+        disableParentheses,
     });
 
     const {
@@ -145,33 +147,36 @@ const PhoneInput = forwardRef(({
                             />
                         )}
                         <div className="mui-phone-input-search-list">
-                            {countriesList.length ? countriesList.map(([iso, name, dial, mask]) => (
-                                <MenuItem
-                                    disableRipple
-                                    key={iso + mask}
-                                    value={iso + dial}
-                                    style={{maxWidth}}
-                                    selected={selectValue === iso + dial}
-                                    onClick={() => {
-                                        const formattedNumber = getFormattedNumber(mask, mask);
-                                        const input = inputRef.current.querySelector("input");
-                                        input.value = formattedNumber;
-                                        setValue(formattedNumber);
-                                        setCountryCode(iso);
-                                        setQuery("");
-                                        const nativeInputValueSetter = (Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") as any).set;
-                                        nativeInputValueSetter.call(input, formattedNumber);
-                                        input.dispatchEvent(new Event("change", {bubbles: true}));
-                                        setTimeout(() => input.focus(), 100);
-                                    }}
-                                    children={<div className="mui-phone-input-select-item">
-                                        <div className={`flag ${iso}`}/>
-                                        <div className="label">
-                                            {name}&nbsp;{displayFormat(mask)}
-                                        </div>
-                                    </div>}
-                                />
-                            )) : <MenuItem disabled>{searchNotFound}</MenuItem>}
+                            {countriesList.length ? countriesList.map(([iso, name, dial, pattern]) => {
+                                const mask = disableParentheses ? pattern.replace(/[()]/g, "") : pattern;
+                                return (
+                                    <MenuItem
+                                        disableRipple
+                                        key={iso + mask}
+                                        value={iso + dial}
+                                        style={{maxWidth}}
+                                        selected={selectValue === iso + dial}
+                                        onClick={() => {
+                                            const formattedNumber = getFormattedNumber(mask, mask);
+                                            const input = inputRef.current.querySelector("input");
+                                            input.value = formattedNumber;
+                                            setValue(formattedNumber);
+                                            setCountryCode(iso);
+                                            setQuery("");
+                                            const nativeInputValueSetter = (Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") as any).set;
+                                            nativeInputValueSetter.call(input, formattedNumber);
+                                            input.dispatchEvent(new Event("change", {bubbles: true}));
+                                            setTimeout(() => input.focus(), 100);
+                                        }}
+                                        children={<div className="mui-phone-input-select-item">
+                                            <div className={`flag ${iso}`}/>
+                                            <div className="label">
+                                                {name}&nbsp;{displayFormat(mask)}
+                                            </div>
+                                        </div>}
+                                    />
+                                )
+                            }) : <MenuItem disabled>{searchNotFound}</MenuItem>}
                         </div>
                     </div>
                 </Select>

--- a/src/joy/index.tsx
+++ b/src/joy/index.tsx
@@ -29,6 +29,7 @@ const PhoneInput = forwardRef(({
                                    disabled = false,
                                    enableSearch = false,
                                    disableDropdown = false,
+                                   disableParentheses = false,
                                    onlyCountries = [],
                                    excludeCountries = [],
                                    preferredCountries = [],
@@ -63,6 +64,7 @@ const PhoneInput = forwardRef(({
         onlyCountries,
         excludeCountries,
         preferredCountries,
+        disableParentheses,
     });
 
     const {
@@ -144,31 +146,34 @@ const PhoneInput = forwardRef(({
                             />
                         )}
                         <div className="mui-phone-input-search-list">
-                            {countriesList.length ? countriesList.map(([iso, name, dial, mask]) => (
-                                <Option
-                                    key={iso + mask}
-                                    style={{maxWidth}}
-                                    value={iso + dial}
-                                    onClick={() => {
-                                        const formattedNumber = getFormattedNumber(mask, mask);
-                                        const input = inputRef.current.querySelector("input");
-                                        input.value = formattedNumber;
-                                        setValue(formattedNumber);
-                                        setCountryCode(iso);
-                                        setQuery("");
-                                        const nativeInputValueSetter = (Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") as any).set;
-                                        nativeInputValueSetter.call(input, formattedNumber);
-                                        input.dispatchEvent(new Event("change", {bubbles: true}));
-                                        setTimeout(() => input.focus(), 100);
-                                    }}
-                                    children={<div className="mui-phone-input-select-item">
-                                        <div className={`flag ${iso}`}/>
-                                        <div className="label">
-                                            {name}&nbsp;{displayFormat(mask)}
-                                        </div>
-                                    </div>}
-                                />
-                            )) : <Option value="N/A" disabled>{searchNotFound}</Option>}
+                            {countriesList.length ? countriesList.map(([iso, name, dial, pattern]) => {
+                                const mask = disableParentheses ? pattern.replace(/[()]/g, "") : pattern;
+                                return (
+                                    <Option
+                                        key={iso + mask}
+                                        style={{maxWidth}}
+                                        value={iso + dial}
+                                        onClick={() => {
+                                            const formattedNumber = getFormattedNumber(mask, mask);
+                                            const input = inputRef.current.querySelector("input");
+                                            input.value = formattedNumber;
+                                            setValue(formattedNumber);
+                                            setCountryCode(iso);
+                                            setQuery("");
+                                            const nativeInputValueSetter = (Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value") as any).set;
+                                            nativeInputValueSetter.call(input, formattedNumber);
+                                            input.dispatchEvent(new Event("change", {bubbles: true}));
+                                            setTimeout(() => input.focus(), 100);
+                                        }}
+                                        children={<div className="mui-phone-input-select-item">
+                                            <div className={`flag ${iso}`}/>
+                                            <div className="label">
+                                                {name}&nbsp;{displayFormat(mask)}
+                                            </div>
+                                        </div>}
+                                    />
+                                )
+                            }) : <Option value="N/A" disabled>{searchNotFound}</Option>}
                         </div>
                     </div>
                 </Select>

--- a/src/joy/types.ts
+++ b/src/joy/types.ts
@@ -21,6 +21,8 @@ export interface PhoneInputProps extends Omit<InputProps, "value" | "onChange"> 
 
     disableDropdown?: boolean;
 
+    disableParentheses?: boolean;
+
     onlyCountries?: string[];
 
     excludeCountries?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export interface PhoneInputProps extends Omit<TextFieldProps, "onChange"> {
 
     disableDropdown?: boolean;
 
+    disableParentheses?: boolean;
+
     onlyCountries?: string[];
 
     excludeCountries?: string[];


### PR DESCRIPTION
### Motivation:

In [react-phone-hooks/v0.1.5](https://github.com/typesnippet/react-phone-hooks/releases/tag/v0.1.5) release, optional parentheses feature has been added, and in this PR, all the necessary changes have been done for supporting `disableParentheses` option.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
