### PR TITLE
Implement an `enableArrow` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Apart from the phone-specific properties described below, all [Input](https://mu
 |--------------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------|
 | value              | An object containing a parsed phone number or the raw number.                                                                 | [object](#value) / string |
 | country            | Country code to be selected by default. By default, it will show the flag of the user's country.                              | string                    |
+| enableArrow        | Shows an arrow next to the country flag. Default value is `false`.                                                            | boolean                   |
 | enableSearch       | Enables search in the country selection dropdown menu. Default value is `false`.                                              | boolean                   |
 | searchVariant      | Accepts an Input variant, and values depend on the chosen Material distribution.                                              | TextFieldVariants         |
 | searchNotFound     | The value is shown if `enableSearch` is `true` and the query does not match any country. Default value is `No country found`. | string                    |

--- a/examples/material/package.json
+++ b/examples/material/package.json
@@ -10,7 +10,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "copy-to-clipboard": "^3.3.3",
-    "mui-phone-input": "^0.1.2",
+    "mui-phone-input": "^0.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.4",

--- a/examples/material/src/Demo.tsx
+++ b/examples/material/src/Demo.tsx
@@ -23,6 +23,7 @@ const Demo = () => {
     const [value, setValue] = useState<any>(null);
     const [mode, setMode] = useState<string>("light");
     const [show, setShow] = useState<boolean>(true);
+    const [arrow, setArrow] = useState<boolean>(false);
     const [strict, setStrict] = useState<boolean>(false);
     const [search, setSearch] = useState<boolean>(false);
     const [copied, setCopied] = useState<boolean>(false);
@@ -50,13 +51,14 @@ const Demo = () => {
     const code = useMemo(() => {
         let code = "<PhoneInput\n";
         if (disabled) code += "    disabled\n";
+        if (arrow) code += "    enableArrow\n";
         if (search && dropdown) code += "    enableSearch\n";
         if (!dropdown) code += "    disableDropdown\n";
         if (!parentheses) code += "    disableParentheses\n";
         if (code === "<PhoneInput\n") code = "<PhoneInput />";
         else code += "/>";
         return code;
-    }, [disabled, search, dropdown, parentheses])
+    }, [disabled, arrow, search, dropdown, parentheses])
 
     return (
         <ThemeProvider theme={theme}>
@@ -113,16 +115,6 @@ const Demo = () => {
                     <div style={{gap: 24, display: "flex", alignItems: "center"}}>
                         <FormControlLabel
                             control={<Switch
-                                color="primary"
-                                disabled={!dropdown}
-                                onChange={() => setSearch(!search)}
-                            />}
-                            labelPlacement="start"
-                            style={{margin: 0}}
-                            label="Search"
-                        />
-                        <FormControlLabel
-                            control={<Switch
                                 defaultChecked
                                 color="primary"
                                 onChange={() => setDropdown(!dropdown)}
@@ -140,6 +132,27 @@ const Demo = () => {
                             labelPlacement="start"
                             style={{margin: 0}}
                             label="Parentheses"
+                        />
+                    </div>
+                    <div style={{gap: 24, display: "flex", alignItems: "center"}}>
+                        <FormControlLabel
+                            control={<Switch
+                                color="primary"
+                                disabled={!dropdown}
+                                onChange={() => setSearch(!search)}
+                            />}
+                            labelPlacement="start"
+                            style={{margin: 0}}
+                            label="Search"
+                        />
+                        <FormControlLabel
+                            control={<Switch
+                                color="primary"
+                                onChange={() => setArrow(!arrow)}
+                            />}
+                            labelPlacement="start"
+                            style={{margin: 0}}
+                            label="Arrow"
                         />
                     </div>
                     <Divider textAlign="left" style={{margin: "16px 0"}}>Code</Divider>
@@ -172,6 +185,7 @@ const Demo = () => {
                                 error={error}
                                 disabled={disabled}
                                 onChange={onChange}
+                                enableArrow={arrow}
                                 enableSearch={search}
                                 style={{width: "100%"}}
                                 disableDropdown={!dropdown}

--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -29,6 +29,7 @@ const PhoneInput = forwardRef(({
                                    searchVariant = undefined,
                                    country = getDefaultISO2Code(),
                                    disabled = false,
+                                   enableArrow = false,
                                    enableSearch = false,
                                    disableDropdown = false,
                                    disableParentheses = false,
@@ -206,10 +207,21 @@ const PhoneInput = forwardRef(({
                     startAdornment: (
                         <InputAdornment position="start">
                             <span
-                                style={{cursor: "pointer"}}
+                                style={{
+                                    display: "flex",
+                                    cursor: "pointer",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                }}
                                 onClick={() => setOpen(!open)}
                             >
                                 <div className={`flag ${countryCode}`}/>
+                                {enableArrow && (
+                                    <svg viewBox="0 0 24 24" focusable="false" fill="currentColor"
+                                         style={{paddingLeft: 4}} width="22" height="20">
+                                        <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"/>
+                                    </svg>
+                                )}
                             </span>
                         </InputAdornment>
                     )

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,6 +13,8 @@ export interface PhoneInputProps extends Omit<TextFieldProps, "onChange"> {
 
     country?: string;
 
+    enableArrow?: boolean;
+
     enableSearch?: boolean;
 
     searchNotFound?: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,7 @@ const PhoneInput = forwardRef(({
                                    searchVariant = undefined,
                                    country = getDefaultISO2Code(),
                                    disabled = false,
+                                   enableArrow = false,
                                    enableSearch = false,
                                    disableDropdown = false,
                                    disableParentheses = false,
@@ -201,10 +202,21 @@ const PhoneInput = forwardRef(({
                     startAdornment: (
                         <InputAdornment position="start">
                             <span
-                                style={{cursor: "pointer"}}
+                                style={{
+                                    display: "flex",
+                                    cursor: "pointer",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                }}
                                 onClick={() => setOpen(!open)}
                             >
                                 <div className={`flag ${countryCode}`}/>
+                                {enableArrow && (
+                                    <svg viewBox="0 0 24 24" focusable="false" fill="currentColor"
+                                         style={{paddingLeft: 4}} width="22" height="20">
+                                        <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"/>
+                                    </svg>
+                                )}
                             </span>
                         </InputAdornment>
                     )

--- a/src/joy/index.tsx
+++ b/src/joy/index.tsx
@@ -28,6 +28,7 @@ const PhoneInput = forwardRef(({
                                    searchVariant = undefined,
                                    country = getDefaultISO2Code(),
                                    disabled = false,
+                                   enableArrow = false,
                                    enableSearch = false,
                                    disableDropdown = false,
                                    disableParentheses = false,
@@ -196,10 +197,21 @@ const PhoneInput = forwardRef(({
                 onKeyDown={onKeyDown}
                 startDecorator={(
                     <span
-                        style={{cursor: "pointer"}}
+                        style={{
+                            display: "flex",
+                            cursor: "pointer",
+                            alignItems: "center",
+                            justifyContent: "center",
+                        }}
                         onClick={() => setOpen(!open)}
                     >
                         <div className={`flag ${countryCode}`}/>
+                        {enableArrow && (
+                            <svg viewBox="0 0 24 24" focusable="false" fill="currentColor"
+                                 style={{paddingLeft: 4}} width="22" height="20">
+                                <path d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"/>
+                            </svg>
+                        )}
                     </span>
                 )}
                 {...(muiInputProps as any)}

--- a/src/joy/types.ts
+++ b/src/joy/types.ts
@@ -13,6 +13,8 @@ export interface PhoneInputProps extends Omit<InputProps, "value" | "onChange"> 
 
     country?: string;
 
+    enableArrow?: boolean;
+
     enableSearch?: boolean;
 
     searchNotFound?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface PhoneInputProps extends Omit<TextFieldProps, "onChange"> {
 
     country?: string;
 
+    enableArrow?: boolean;
+
     enableSearch?: boolean;
 
     searchNotFound?: string;


### PR DESCRIPTION
### Motivation:

These changes originated from the #18 issue. Implemented an `enableArrow` option with a default `false` value. It's been tested with different themes and is available in the playground so people can test it before installing it.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](./CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you updated the documentation related to the changes you have made?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
